### PR TITLE
Update skale.py to 7.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
     "apscheduler==3.11.0",
     "peewee==3.18.2",
     "schedule==1.2.2",
-    "skale.py==7.6dev3",
+    "skale.py==7.10dev4",
     "tenacity==9.1.2",
 ]
 [project.optional-dependencies]


### PR DESCRIPTION
This pull request updates the `skale.py` dependency to a newer development version in the `pyproject.toml` file.

- Dependency update:
  * Upgraded `skale.py` from version `7.6dev3` to `7.10dev4` in the `dependencies` list in `pyproject.toml`.